### PR TITLE
fix installation instruction and improved item number display

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,22 @@ cd ~/.todo.actions.d
 
 Clone this directory into a new directory `due`:
 ```
-git clone https://github.com/rebeccamorgan/due.git due
+git clone https://github.com/rebeccamorgan/due.git due.git
 ```
 
-Now `cd` into this new `due` directory and make the shell script executable:
+Move the `due` and `due.py` scripts out of `due.git` directory:
+```
+mv ./due.git/due ./due.git/due.py ./
+```
+
+Now make the `due` shell script executable:
 ```
 chmod +x due
+```
+
+Finally, remove the repo directory `due.git`:
+```
+rm -rf ./due.git
 ```
 
 # Usage

--- a/due
+++ b/due
@@ -14,5 +14,5 @@ shift
 }
 
 [ "$action" = "due" ] && {
-     python ${TODO_ACTIONS_DIR}/due/due.py "$TODO_DIR" $flag
+     python ${TODO_ACTIONS_DIR}/due.py "$TODO_DIR" $flag
 }

--- a/due.py
+++ b/due.py
@@ -11,6 +11,9 @@ import sys
 from datetime import datetime, timedelta
 import re
 
+def lo(num):
+    return "0"+str(num) if num < 10 else str(num)
+
 def main(todo_dir, future_days = 0):
     # Prepare lists to store tasks
     overdue = list()
@@ -31,11 +34,11 @@ def main(todo_dir, future_days = 0):
 
                 # Add matching tasks to list with line number
                 if date < datetime.today().date():
-                    overdue.append(str(i+1) + " " + task)
+                    overdue.append(lo(i+1) + " " + task)
                 elif date == datetime.today().date():
-                    due_today.append(str(i+1) + " " + task)
+                    due_today.append(lo(i+1) + " " + task)
                 elif date < datetime.today().date() + timedelta(days=future_days+1):
-                    due_future.append(str(i+1) + " " + task)
+                    due_future.append(lo(i+1) + " " + task)
 
     # Print to console
     if len(overdue) > 0:

--- a/due.py
+++ b/due.py
@@ -11,9 +11,6 @@ import sys
 from datetime import datetime, timedelta
 import re
 
-def lo(num):
-    return "0"+str(num) if num < 10 else str(num)
-
 def main(todo_dir, future_days = 0):
     # Prepare lists to store tasks
     overdue = list()
@@ -34,11 +31,11 @@ def main(todo_dir, future_days = 0):
 
                 # Add matching tasks to list with line number
                 if date < datetime.today().date():
-                    overdue.append(lo(i+1) + " " + task)
+                    overdue.append(str(i+1).zfill(2) + " " + task)
                 elif date == datetime.today().date():
-                    due_today.append(lo(i+1) + " " + task)
+                    due_today.append(str(i+1).zfill(2) + " " + task)
                 elif date < datetime.today().date() + timedelta(days=future_days+1):
-                    due_future.append(lo(i+1) + " " + task)
+                    due_future.append(str(i+1).zfill(2) + " " + task)
 
     # Print to console
     if len(overdue) > 0:


### PR DESCRIPTION
Not sure how cloning the repo and right into `.todo.actions.d` helps todo.txt-cli run it. It just didn't work on my machine so I modified the installation instruction.

Also improved item number display, padding '0' before any number less than 10.