### PR TITLE
Simplify installation to a simple clone into .todo.actions.d by disco…

### DIFF
--- a/due
+++ b/due
@@ -14,5 +14,5 @@ shift
 }
 
 [ "$action" = "due" ] && {
-     python ${TODO_ACTIONS_DIR}/due.py "$TODO_DIR" $flag
+     python $(dirname $0)/due.py "$TODO_DIR" $flag
 }


### PR DESCRIPTION
This minor change will discover the location of the due shell script and use it to launch todo.  Save all the mess of moving files on install.  Just a clone should do, and allow pulling future updates.