### PR TITLE
clear syntax warning about using `is` for literal

### DIFF
--- a/due.py
+++ b/due.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     if os.path.isfile(sys.argv[1]):
-        if len(sys.argv) is 3:
+        if len(sys.argv) == 3:
             main(sys.argv[1], int(sys.argv[2]))
         else:
             main(sys.argv[1])


### PR DESCRIPTION
With python 3.8.0, I received the following prior to this fix: `SyntaxWarning: "is" with a literal. Did you mean "=="?`