### PR TITLE
Allow due date at beginning of task name

### DIFF
--- a/due.py
+++ b/due.py
@@ -53,11 +53,11 @@ def main(todo_file, future_days=0):
 
         for i, task in enumerate(content):
             match = re.findall(
-                r"(\([A-Z]\))?[A-Za-z0-9+@\s]+%s:(\d{4}-\d{2}-\d{2})" % key, task
+                 r"%s:(\d{4}-\d{2}-\d{2})" % key, task
             )
 
             if match:
-                date = datetime.strptime(match[0][1], "%Y-%m-%d").date()
+                date = datetime.strptime(match[0], "%Y-%m-%d").date()
                 tasks_with_date.append((i, task, date))
 
         # Sort tasks with a due date: regex by date, then priority

--- a/due.py
+++ b/due.py
@@ -53,7 +53,7 @@ def main(todo_file, future_days=0):
 
         for i, task in enumerate(content):
             match = re.findall(
-                 r"%s:(\d{4}-\d{2}-\d{2})" % key, task
+                r"%s:(\d{4}-\d{2}-\d{2})" % key, task
             )
 
             if match:


### PR DESCRIPTION
I tweaked the regex so that it will properly detect the due date if it's at the beginning, e.g. `due:2020-05-06 abcabc`