### PR TITLE
Use python3 to run due.py instead of python

### DIFF
--- a/due
+++ b/due
@@ -14,5 +14,5 @@ shift
 }
 
 [ "$action" = "due" ] && {
-     python $(dirname $0)/due.py "$TODO_FILE" $flag
+     python3 $(dirname $0)/due.py "$TODO_FILE" $flag
 }


### PR DESCRIPTION
Calling explicitly python3 to run `due.py` allows one to use the extension on computer where both python2 and python3 are installed but python2 is the default (invoking `python` cause `python2` to be executed).

As the compatibility with python2 was dropped previously, I guess updating the script that way is ok?

Thanks for this extension btw, I'm starting to use todo.txt and it will be useful. :-)